### PR TITLE
Reset when the revision matches the current branch

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -128,10 +128,10 @@ if [ -d "$CLONE_DIR" ]; then
 
           CURRENT_BRANCH="`git branch 2>/dev/null | grep '^*' | cut -d' ' -f2-`"
 
-          # If the revision is identical to the current branch we can rebase it with the latest changes. This isn't needed when running detached
+          # If the revision is identical to the current branch we can just reset it to the latest changes. This isn't needed when running detached
           if [ "$REVISION" == "$CURRENT_BRANCH" ]; then
-             echo 'Rebasing current branch $REVISION to latest changes...'
-             git rebase
+             echo 'Resetting current branch $REVISION to latest changes...'
+             git reset --hard origin/$REVISION
           fi
       fi
   else


### PR DESCRIPTION
If the cached version on disk has a different tree from origin (maybe a force push of a different tree), the rebase will fail.  We may as well just reset it and forgo the rebase.